### PR TITLE
explicitly set RestTemplate's message converters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,12 @@
             <version>1.9.12</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.5.1</version>
+            <scope>test</scope> <!-- to test de/serialization works even with jackson2 on classpath -->
+        </dependency>
+        <dependency>
             <groupId>com.github.lookfirst</groupId>
             <artifactId>sardine</artifactId>
             <version>5.1</version>


### PR DESCRIPTION
Jackson2 on classpath breaks de/serialization this time via AllEncompassingFormHttpMessageConverter which uses classpath detection and favours Jackson2 over Jackson1.

Closes: #121 Relates: #80