### PR TITLE
throw different exceptions during report exporting

### DIFF
--- a/src/main/java/com/gooddata/report/NoDataReportException.java
+++ b/src/main/java/com/gooddata/report/NoDataReportException.java
@@ -1,0 +1,16 @@
+package com.gooddata.report;
+
+/**
+ * Thrown when report export contains no data
+ */
+public class NoDataReportException extends ReportException {
+
+    public NoDataReportException() {
+        this("Report contains no data");
+    }
+
+    public NoDataReportException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/gooddata/report/ReportService.java
+++ b/src/main/java/com/gooddata/report/ReportService.java
@@ -44,6 +44,8 @@ public class ReportService extends AbstractService {
      * @param format export format
      * @param output target
      * @return polling result
+     * @throws NoDataReportException in case report contains no data
+     * @throws ReportException on error
      */
     public FutureResult<Void> exportReport(final ReportDefinition reportDefinition, final ReportExportFormat format,
                                            final OutputStream output) {
@@ -58,6 +60,8 @@ public class ReportService extends AbstractService {
      * @param format export format
      * @param output target
      * @return polling result
+     * @throws NoDataReportException in case report contains no data
+     * @throws ReportException on error
      */
     public FutureResult<Void> exportReport(final Report report, final ReportExportFormat format,
                                            final OutputStream output) {
@@ -77,7 +81,7 @@ public class ReportService extends AbstractService {
                 switch (response.getStatusCode()) {
                     case OK: return true;
                     case ACCEPTED: return false;
-                    case NO_CONTENT: throw new ReportException("Report contains no data");
+                    case NO_CONTENT: throw new NoDataReportException();
                     default: throw new ReportException("Unable to export report, unknown HTTP response code: " + response.getStatusCode());
                 }
             }

--- a/src/test/java/com/gooddata/report/ReportServiceIT.java
+++ b/src/test/java/com/gooddata/report/ReportServiceIT.java
@@ -74,4 +74,17 @@ public class ReportServiceIT extends AbstractGoodDataIT {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         gd.getReportService().exportReport(rd, ReportExportFormat.CSV, output).get();
     }
+
+    @Test(expectedExceptions = NoDataReportException.class, expectedExceptionsMessageRegExp = "Report contains no data")
+    public void shouldFailNoData() throws Exception {
+        onRequest()
+                .havingPathEqualTo(URI)
+                .havingMethodEqualTo("GET")
+                .respond()
+                .withStatus(204);
+
+        final Report rd = MAPPER.readValue(readFromResource("/md/report/report.json"), Report.class);
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        gd.getReportService().exportReport(rd, ReportExportFormat.CSV, output).get();
+    }
 }


### PR DESCRIPTION
It can be usefull to distinguish between no data and other error during
report export.