### PR TITLE
BUILD: Check that all used dependencies are also declared

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <httpclient.version>4.3.3</httpclient.version>
+        <jackson-asl.version>1.9.12</jackson-asl.version>
+        <spring.version>3.2.13.RELEASE</spring.version>
+        <jadler.version>1.1.1</jadler.version>
+        <json-unit.version>1.5.3</json-unit.version>
     </properties>
 
     <build>
@@ -82,6 +86,23 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                            <ignoreNonCompile>true</ignoreNonCompile>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -178,6 +199,11 @@
             <version>0.8.3</version>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
@@ -189,8 +215,13 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>3.2.13.RELEASE</version>
+            <version>${spring.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>aopalliance</groupId>
@@ -208,8 +239,13 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+            <version>${jackson-asl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.12</version>
+            <version>${jackson-asl.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -228,6 +264,12 @@
             <version>2.7</version>
         </dependency>
 
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
@@ -255,7 +297,13 @@
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit</artifactId>
-            <version>1.5.3</version>
+            <version>${json-unit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-core</artifactId>
+            <version>${json-unit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -266,8 +314,14 @@
         </dependency>
         <dependency>
             <groupId>net.jadler</groupId>
+            <artifactId>jadler-core</artifactId>
+            <version>${jadler.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.jadler</groupId>
             <artifactId>jadler-all</artifactId>
-            <version>1.1.1</version>
+            <version>${jadler.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
It is not good practice to rely on transitive deps as your project can
be easily broken by updating your deps. All used dependencies should
be declared.

maven-dependecy-plugin is now configured to break build if any used dep
is not declared. Unfortunately problematic deps are shown only as
warnings.