### PR TITLE
metadata AbstractObj no longer implements Obj

### DIFF
--- a/src/main/java/com/gooddata/md/AbstractObj.java
+++ b/src/main/java/com/gooddata/md/AbstractObj.java
@@ -12,7 +12,7 @@ import static com.gooddata.util.Validate.noNullElements;
 /**
  * Metadata object (common part)
  */
-public abstract class AbstractObj implements Obj {
+public abstract class AbstractObj {
 
     @JsonProperty("meta")
     protected final Meta meta;

--- a/src/main/java/com/gooddata/md/Obj.java
+++ b/src/main/java/com/gooddata/md/Obj.java
@@ -3,7 +3,7 @@ package com.gooddata.md;
 import org.springframework.web.util.UriTemplate;
 
 /**
- * Metadata object
+ * First class metadata object - only dto objects, which have URI pointing to themselves should implement this.
  */
 public interface Obj {
 

--- a/src/main/java/com/gooddata/md/ObjNotFoundException.java
+++ b/src/main/java/com/gooddata/md/ObjNotFoundException.java
@@ -12,7 +12,7 @@ public class ObjNotFoundException extends GoodDataException {
      *
      * @param uri the URI of metadata object you're searching for
      * @param cls class of metadata object you're searching for
-     * @param e   caused by this exception
+     * @param e   caused of this exception
      * @param <T> the type of results you're searching for
      */
     public <T extends Obj> ObjNotFoundException(String uri, Class<T> cls, Exception e) {
@@ -23,7 +23,6 @@ public class ObjNotFoundException extends GoodDataException {
      * Construct a new instance of ObjNotFoundException.
      *
      * @param obj metadata object you're working with
-     * @param <T> the type of results you're searching for
      */
     public ObjNotFoundException(Obj obj) {
         super(obj.getClass().getSimpleName() + " not found " + obj.getUri());
@@ -44,7 +43,7 @@ public class ObjNotFoundException extends GoodDataException {
      * @param cls class of metadata object you're searching for
      * @param <T> the type of results you're searching for
      */
-    public <T> ObjNotFoundException(Class<T> cls) {
+    public <T extends Obj> ObjNotFoundException(Class<T> cls) {
         super(cls.getSimpleName() + " not found");
     }
 }


### PR DESCRIPTION
AbstractObj is useful ancestor keeping most of metadata objects, including those which can't be considered
 as first class citizens (they are nested into another object and it is not possible to manipulate them directly)

closes #188 