### PR TITLE
fix: use fixed version of gooddata-http-client with correct logout request recongnition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <dependency>
             <groupId>com.gooddata</groupId>
             <artifactId>gooddata-http-client</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
The 0.9.2 version has fixed logout, but only for calls of execute method with host. 0.9.3 correctly detects also the situation when full uri is given in http method.

closes #244