### PR TITLE
DataStoreService is now able to delete WebDav collections.

### DIFF
--- a/src/main/java/com/gooddata/GoodData.java
+++ b/src/main/java/com/gooddata/GoodData.java
@@ -174,7 +174,7 @@ public class GoodData {
         metadataService = new MetadataService(getRestTemplate());
         modelService = new ModelService(getRestTemplate());
         gdcService = new GdcService(getRestTemplate());
-        dataStoreService = new DataStoreService(httpClient, gdcService, new HttpHost(hostname, port, protocol).toURI());
+        dataStoreService = new DataStoreService(httpClient, getRestTemplate(), gdcService, new HttpHost(hostname, port, protocol).toURI());
         datasetService = new DatasetService(getRestTemplate(), dataStoreService);
         reportService = new ReportService(getRestTemplate());
         processService = new ProcessService(getRestTemplate(), accountService, dataStoreService);

--- a/src/main/java/com/gooddata/UriPrefixer.java
+++ b/src/main/java/com/gooddata/UriPrefixer.java
@@ -54,7 +54,7 @@ public class UriPrefixer {
      */
     public URI mergeUris(URI uri) {
         notNull(uri, "uri");
-        final String path = trimTrailingCharacter(trimLeadingCharacter(uri.getRawPath(), '/'), '/');
+        final String path = trimLeadingCharacter(uri.getRawPath(), '/');
         return UriComponentsBuilder.fromUri(uriPrefix)
                 .pathSegment(path)
                 .query(uri.getRawQuery())

--- a/src/main/java/com/gooddata/dataset/DatasetService.java
+++ b/src/main/java/com/gooddata/dataset/DatasetService.java
@@ -206,7 +206,7 @@ public class DatasetService extends AbstractService {
             @Override
             protected void onFinish() {
                 try {
-                    dataStoreService.delete(dirPath.toString() + "/");
+                    dataStoreService.delete(dirPath.toString());
                 } catch (DataStoreException ignored) {
                     // todo log?
                 }

--- a/src/test/java/com/gooddata/AbstractGoodDataAT.java
+++ b/src/test/java/com/gooddata/AbstractGoodDataAT.java
@@ -40,11 +40,9 @@ public abstract class AbstractGoodDataAT {
 
     @AfterSuite
     public static void removeProjectAndLogout() {
-        if (gd != null) {
-            if (project != null) {
-                gd.getProjectService().removeProject(project);
-            }
-            gd.logout();
+        if (project != null) {
+            gd.getProjectService().removeProject(project);
         }
+        gd.logout();
     }
 }

--- a/src/test/java/com/gooddata/AbstractGoodDataIT.java
+++ b/src/test/java/com/gooddata/AbstractGoodDataIT.java
@@ -3,16 +3,12 @@
  */
 package com.gooddata;
 
-import com.gooddata.util.ResourceUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-import java.io.InputStream;
-
-import static com.gooddata.util.Validate.notNull;
 import static net.jadler.Jadler.closeJadler;
 import static net.jadler.Jadler.initJadler;
 import static net.jadler.Jadler.port;

--- a/src/test/java/com/gooddata/JsonMatchers.java
+++ b/src/test/java/com/gooddata/JsonMatchers.java
@@ -1,8 +1,6 @@
 package com.gooddata;
 
-import net.javacrumbs.jsonunit.JsonAssert;
 import net.javacrumbs.jsonunit.core.Configuration;
-import net.javacrumbs.jsonunit.core.Option;
 import net.javacrumbs.jsonunit.core.internal.Diff;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.BaseMatcher;

--- a/src/test/java/com/gooddata/collections/UriPageTest.java
+++ b/src/test/java/com/gooddata/collections/UriPageTest.java
@@ -4,17 +4,12 @@ import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-
 import static java.util.Collections.singletonList;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
-import static org.testng.Assert.fail;
 
 public class UriPageTest {
 

--- a/src/test/java/com/gooddata/dataload/processes/ScheduleTest.java
+++ b/src/test/java/com/gooddata/dataload/processes/ScheduleTest.java
@@ -1,7 +1,6 @@
 package com.gooddata.dataload.processes;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.collection.IsMapContaining;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.mockito.Matchers;
@@ -14,7 +13,6 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 
 import static com.gooddata.JsonMatchers.serializesToJson;
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;

--- a/src/test/java/com/gooddata/dataset/DatasetServiceIT.java
+++ b/src/test/java/com/gooddata/dataset/DatasetServiceIT.java
@@ -49,6 +49,11 @@ public class DatasetServiceIT extends AbstractGoodDataIT {
             .respond()
                 .withStatus(200);
         onRequest()
+                .havingPath(startsWith("/uploads/"))
+                .havingMethodEqualTo("DELETE")
+            .respond()
+                .withStatus(200);
+        onRequest()
                 .havingPathEqualTo("/gdc/md/PROJECT_ID/etl/pull")
                 .havingMethodEqualTo("POST")
             .respond()

--- a/src/test/java/com/gooddata/dataset/FailStatusTest.java
+++ b/src/test/java/com/gooddata/dataset/FailStatusTest.java
@@ -4,7 +4,6 @@ import com.gooddata.gdc.ErrorStructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.hamcrest.Matchers;
 import org.testng.annotations.Test;
 
 import java.io.InputStream;

--- a/src/test/java/com/gooddata/gdc/DatastoreServiceAT.java
+++ b/src/test/java/com/gooddata/gdc/DatastoreServiceAT.java
@@ -1,7 +1,7 @@
 package com.gooddata.gdc;
 
 import com.gooddata.AbstractGoodDataAT;
-import com.gooddata.gdc.DataStoreService;
+import com.gooddata.GoodDataRestException;
 import org.apache.commons.io.IOUtils;
 import org.testng.annotations.Test;
 
@@ -10,18 +10,23 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.util.UUID;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 /**
  * Data store acceptance test
  */
 public class DatastoreServiceAT extends AbstractGoodDataAT {
 
     private String file;
+    private String directory;
 
     @Test(groups = "datastore", dependsOnGroups = "account")
     public void datastoreUpload() throws Exception {
         DataStoreService dataStoreService = gd.getDataStoreService();
 
-        file = "/" + UUID.randomUUID().toString() + "/file.csv";
+        directory = "/" + UUID.randomUUID().toString();
+        file = directory + "/file.csv";
         dataStoreService.upload(file, getClass().getResourceAsStream("/person.csv"));
     }
 
@@ -42,5 +47,13 @@ public class DatastoreServiceAT extends AbstractGoodDataAT {
     public void datastoreDelete() throws Exception {
         DataStoreService dataStoreService = gd.getDataStoreService();
         dataStoreService.delete(this.file);
+        dataStoreService.delete(this.directory);
+
+        try {
+            dataStoreService.delete(this.directory);
+            fail("Exception was expected, as there is nothing to delete");
+        } catch (GoodDataRestException e) {
+            assertEquals(404, e.getStatusCode());
+        }
     }
 }


### PR DESCRIPTION
The root cause of the problem was in the 'sardine' library not following
HTTP 301 redirects when doing DELETE on resource on WebDav.

In case of GD WebDav infrastructure, when you want to delete collection,
you need to execute DELETE on resource with trailing '/', otherwise you
get HTTP 301 with correct location.