### PR TITLE
fix webdav upload 500 response by lowering the 100 (continue) wait timeout

### DIFF
--- a/src/main/java/com/gooddata/GoodData.java
+++ b/src/main/java/com/gooddata/GoodData.java
@@ -24,6 +24,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpRequestExecutor;
 import org.apache.http.util.VersionInfo;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -211,7 +212,8 @@ public class GoodData {
         return HttpClientBuilder.create()
                 .setUserAgent(getUserAgent())
                 .setConnectionManager(connectionManager)
-                .setDefaultRequestConfig(requestConfig.build());
+                .setDefaultRequestConfig(requestConfig.build())
+                .setRequestExecutor(new HttpRequestExecutor(settings.getWaitForContinueTimeout()));
     }
 
     /*

--- a/src/main/java/com/gooddata/GoodDataSettings.java
+++ b/src/main/java/com/gooddata/GoodDataSettings.java
@@ -17,6 +17,7 @@ public class GoodDataSettings {
     private int connectionTimeout = secondsToMillis(10);
     private int connectionRequestTimeout = secondsToMillis(10);
     private int socketTimeout = secondsToMillis(60);
+    private int waitForContinueTimeout = secondsToMillis(1);
 
 
     /**
@@ -150,6 +151,45 @@ public class GoodDataSettings {
         return socketTimeout;
     }
 
+    /**
+     * Set timeout for wait on 100 (Continue) or final response after sending initial part of the request.
+     * It typically affects WebDAV PUT requests (when Expect: 100-continue header is set).
+     * <p>
+     * The default value is 1 second (1000 milliseconds).
+     * </p>
+     * Can't be zero or negative.
+     *
+     * @param waitForContinueTimeout wait for continue timeout milliseconds
+     */
+    public void setWaitForContinueTimeout(int waitForContinueTimeout) {
+        isTrue(waitForContinueTimeout > 0, "waitForContinueTimeout must be positive");
+        this.waitForContinueTimeout = waitForContinueTimeout;
+    }
+
+    /**
+     * Set timeout for wait on 100 (Continue) or final response seconds after sending initial part of the request.
+     * It typically affects WebDAV PUT requests (when Expect: 100-continue header is set).
+     * <p>
+     * The default value is 1 second .
+     * </p>
+     * Can't be zero or negative.
+     *
+     * @param waitForContinueTimeout wait for continue timeout seconds
+     */
+    public void setWaitForContinueTimeoutSeconds(int waitForContinueTimeout) {
+        setWaitForContinueTimeout(secondsToMillis(waitForContinueTimeout));
+    }
+
+    /**
+     * Milliseconds for wait on 100 (Continue) or final response after sending initial part of the request.
+     * It typically affects WebDAV PUT requests (when Expect: 100-continue header is set).
+     *
+     * @return milliseconds for wait on 100 (Continue) after sending initial part of the request
+     */
+    public int getWaitForContinueTimeout() {
+        return waitForContinueTimeout;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
@@ -160,7 +200,8 @@ public class GoodDataSettings {
         if (maxConnections != that.maxConnections) return false;
         if (connectionTimeout != that.connectionTimeout) return false;
         if (connectionRequestTimeout != that.connectionRequestTimeout) return false;
-        return socketTimeout == that.socketTimeout;
+        if (socketTimeout != that.socketTimeout) return false;
+        return waitForContinueTimeout == that.waitForContinueTimeout;
 
     }
 
@@ -170,6 +211,7 @@ public class GoodDataSettings {
         result = 31 * result + connectionTimeout;
         result = 31 * result + connectionRequestTimeout;
         result = 31 * result + socketTimeout;
+        result = 31 * result + waitForContinueTimeout;
         return result;
     }
 
@@ -180,6 +222,7 @@ public class GoodDataSettings {
                 ", maxConnections=" + maxConnections +
                 ", connectionTimeout=" + connectionTimeout +
                 ", socketTimeout=" + socketTimeout +
+                ", waitForContinueTimeout=" + waitForContinueTimeout +
                 '}';
     }
 

--- a/src/test/java/com/gooddata/GoodDataSettingsTest.java
+++ b/src/test/java/com/gooddata/GoodDataSettingsTest.java
@@ -21,6 +21,7 @@ public class GoodDataSettingsTest {
         assertTrue(settings.getConnectionTimeout() >= 0);
         assertTrue(settings.getConnectionRequestTimeout() >= 0);
         assertTrue(settings.getSocketTimeout() >= 0);
+        assertTrue(settings.getWaitForContinueTimeout() > 0);
     }
 
     @Test
@@ -28,10 +29,12 @@ public class GoodDataSettingsTest {
         settings.setConnectionTimeoutSeconds(53);
         settings.setConnectionRequestTimeoutSeconds(69);
         settings.setSocketTimeoutSeconds(71);
+        settings.setWaitForContinueTimeoutSeconds(2);
 
         assertEquals(53000, settings.getConnectionTimeout());
         assertEquals(69000, settings.getConnectionRequestTimeout());
         assertEquals(71000, settings.getSocketTimeout());
+        assertEquals(2000, settings.getWaitForContinueTimeout());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
@@ -52,5 +55,10 @@ public class GoodDataSettingsTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void setZeroMaxConnectionsFails() throws Exception {
         settings.setMaxConnections(0);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void setNegativeWaitForContinueTimeoutFails() throws Exception {
+        settings.setWaitForContinueTimeout(-2);
     }
 }

--- a/src/test/java/com/gooddata/gdc/DatastoreServiceAT.java
+++ b/src/test/java/com/gooddata/gdc/DatastoreServiceAT.java
@@ -1,8 +1,11 @@
 package com.gooddata.gdc;
 
 import com.gooddata.AbstractGoodDataAT;
+import com.gooddata.GoodData;
 import com.gooddata.GoodDataRestException;
 import org.apache.commons.io.IOUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -21,11 +24,15 @@ public class DatastoreServiceAT extends AbstractGoodDataAT {
     private String file;
     private String directory;
 
+    @BeforeClass
+    public void setUp() throws Exception {
+        directory = "/" + UUID.randomUUID().toString();
+    }
+
     @Test(groups = "datastore", dependsOnGroups = "account")
     public void datastoreUpload() throws Exception {
         DataStoreService dataStoreService = gd.getDataStoreService();
 
-        directory = "/" + UUID.randomUUID().toString();
         file = directory + "/file.csv";
         dataStoreService.upload(file, getClass().getResourceAsStream("/person.csv"));
     }
@@ -54,6 +61,22 @@ public class DatastoreServiceAT extends AbstractGoodDataAT {
             fail("Exception was expected, as there is nothing to delete");
         } catch (GoodDataRestException e) {
             assertEquals(404, e.getStatusCode());
+        }
+    }
+
+    @Test(groups = "datastore")
+    public void datastoreUploadWithAuthentication() throws Exception {
+
+        //TODO this doesn't work because we can't read the underlying stream twice
+        final GoodData datastoreGd = new GoodData(getProperty("host"), getProperty("login"), getProperty("pass"));
+        DataStoreService dataStoreService = datastoreGd.getDataStoreService();
+
+        try {
+            final String fileWithAuth = directory + "/fileWithAuth.csv";
+            dataStoreService.upload(fileWithAuth, getClass().getResourceAsStream("/person.csv"));
+            dataStoreService.delete(fileWithAuth);
+        } finally {
+            datastoreGd.logout();
         }
     }
 }


### PR DESCRIPTION
The default timeout in apache HttpClient is 3s. Since the gooddata webdav never sends 100 (continue) response as specification suggests, it causes unfortunate 3s delay in each PUT on webdav. Additionaly it caused 500 when the PUT was unauthenticated. When this timeout is lowered (approx less than 2s) it can work smoothly. So this brings configurable waitForContinue timeout with default of 1s.

resolves #248 