### PR TITLE
Metric.MaqlAst.content is serialized as 'absent' instead of null

### DIFF
--- a/src/main/java/com/gooddata/md/MaqlAst.java
+++ b/src/main/java/com/gooddata/md/MaqlAst.java
@@ -4,12 +4,13 @@
 package com.gooddata.md;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * MAQL AST representation
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MaqlAst {
 
     private final String type;

--- a/src/test/java/com/gooddata/JsonMatchers.java
+++ b/src/test/java/com/gooddata/JsonMatchers.java
@@ -1,21 +1,22 @@
 package com.gooddata;
 
-import net.javacrumbs.jsonunit.core.Configuration;
-import net.javacrumbs.jsonunit.core.internal.Diff;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.hamcrest.Factory;
-import org.hamcrest.Matcher;
+import static java.lang.String.format;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.internal.Diff.create;
 
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import static java.lang.String.format;
-import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
-import static net.javacrumbs.jsonunit.core.Option.TREATING_NULL_AS_ABSENT;
-import static net.javacrumbs.jsonunit.core.internal.Diff.create;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import net.javacrumbs.jsonunit.core.Configuration;
+import net.javacrumbs.jsonunit.core.internal.Diff;
 
 /**
  * Contains Hamcrest matchers to be used with Hamcrest assertThat and other tools.
@@ -81,7 +82,7 @@ public class JsonMatchers {
             }
 
             this.expectedJsonString = expectedJsonString;
-            final Diff diff = create(expectedJsonString, actual, "fullJson", "", Configuration.empty().withOptions(TREATING_NULL_AS_ABSENT, IGNORING_ARRAY_ORDER));
+            final Diff diff = create(expectedJsonString, actual, "fullJson", "", Configuration.empty().withOptions(IGNORING_ARRAY_ORDER));
             if (!diff.similar()) {
                 differences = diff.differences();
             }

--- a/src/test/java/com/gooddata/md/MetricTest.java
+++ b/src/test/java/com/gooddata/md/MetricTest.java
@@ -3,13 +3,16 @@
  */
 package com.gooddata.md;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.testng.annotations.Test;
-
 import static com.gooddata.JsonMatchers.serializesToJson;
+import static net.javacrumbs.jsonunit.JsonMatchers.jsonNodeAbsent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class MetricTest {
 
@@ -24,6 +27,12 @@ public class MetricTest {
         assertThat(metric.getMaqlAst().getPosition().getColumn(), is(1));
         assertThat(metric.getMaqlAst().getType(), is("metric"));
         assertThat(metric.getMaqlAst().getContent().length, is(1));
+        assertThat(metric.getMaqlAst().getContent()[0].getContent().length, is(1));
+        assertThat(metric.getMaqlAst().getContent()[0].getContent()[0].getValue(), is("AVG"));
+        assertThat(metric.getMaqlAst().getContent()[0].getContent()[0].getContent().length, is(1));
+        assertThat(metric.getMaqlAst().getContent()[0].getContent()[0].getContent()[0].getValue(),
+                is("/gdc/md/PROJECT_ID/obj/EXPR_ID"));
+        assertThat(metric.getMaqlAst().getContent()[0].getContent()[0].getContent()[0].getContent(), nullValue());
     }
 
     @Test
@@ -36,6 +45,8 @@ public class MetricTest {
     public void fullJsonShouldStayTheSameAfterDeserializationAndSerializationBack() throws Exception {
         final Metric metric = new ObjectMapper()
                 .readValue(getClass().getResourceAsStream("/md/metric-out.json"), Metric.class);
+
+        assertThat(metric, jsonNodeAbsent("metric.content.tree.content[0].content[0].content[0].content"));
         assertThat(metric, serializesToJson("/md/metric-out.json"));
     }
 }


### PR DESCRIPTION
Fix the problem when Metric is created and later updated by MetadataService.
In case that Metric is created the Metric.MaqlAst.content might be null in some cases
which leads to failed call (400 MD server response) during update.