### PR TITLE
Add @SafeVarargs to MetadataService.usedBy methods

### DIFF
--- a/src/main/java/com/gooddata/md/MetadataService.java
+++ b/src/main/java/com/gooddata/md/MetadataService.java
@@ -306,7 +306,8 @@ public class MetadataService extends AbstractService {
      *                'table'...)
      * @return objects using given objects.
      */
-    public Collection<Entry> usedBy(Project project, Obj obj, boolean nearest, Class<? extends Obj>... types) {
+    @SafeVarargs
+    public final Collection<Entry> usedBy(Project project, Obj obj, boolean nearest, Class<? extends Obj>... types) {
         notNull(obj, "obj");
         return usedBy(project, obj.getUri(), nearest, types);
     }
@@ -321,7 +322,8 @@ public class MetadataService extends AbstractService {
      * @return objects using given objects.
      * @see #usedBy(Project, Collection, boolean, Class[])
      */
-    public Collection<Entry> usedBy(Project project, String uri, boolean nearest, Class<? extends Obj>... types) {
+    @SafeVarargs
+    public final Collection<Entry> usedBy(Project project, String uri, boolean nearest, Class<? extends Obj>... types) {
         notNull(uri, "uri");
         notNull(project, "project");
 
@@ -339,7 +341,8 @@ public class MetadataService extends AbstractService {
      * @return objects usages
      * @see #usedBy(Project, String, boolean, Class[])
      */
-    public Collection<Usage> usedBy(Project project, Collection<String> uris, boolean nearest, Class<? extends Obj>... types) {
+    @SafeVarargs
+    public final Collection<Usage> usedBy(Project project, Collection<String> uris, boolean nearest, Class<? extends Obj>... types) {
         notNull(uris, "uris");
         notNull(project, "project");
 


### PR DESCRIPTION
It's necessary to make those methods final and
that's not backward compatible.

Fixes #296 