### PR TITLE
Get rid of UriResponse from object APIs

### DIFF
--- a/src/main/java/com/gooddata/gdc/UriResponse.java
+++ b/src/main/java/com/gooddata/gdc/UriResponse.java
@@ -9,7 +9,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Response containing URI
+ * Response containing URI string.
+ * <p>
+ * Intended for internal library purposes only, not to be used in public API!
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/gooddata/md/DataLoadingColumn.java
+++ b/src/main/java/com/gooddata/md/DataLoadingColumn.java
@@ -33,8 +33,8 @@ public class DataLoadingColumn extends AbstractObj implements Queryable {
         this.content = content;
     }
 
-    public UriResponse getColumnUri() {
-        return content.getColumnUri();
+    public String getColumnUri() {
+        return content.getColumnUri().getUri();
     }
 
     public String getName() {

--- a/src/main/java/com/gooddata/md/maintenance/ExportImportService.java
+++ b/src/main/java/com/gooddata/md/maintenance/ExportImportService.java
@@ -47,7 +47,7 @@ public class ExportImportService extends AbstractService {
             throw new ExportImportException("Unable to export metadata from objects " + export.getUris() + ".", e);
         }
 
-        return new PollResult<>(this, new AbstractPollHandler<TaskStatus, PartialMdExportToken>(partialMdArtifact.getStatus().getUri(),
+        return new PollResult<>(this, new AbstractPollHandler<TaskStatus, PartialMdExportToken>(partialMdArtifact.getStatusUri(),
                 TaskStatus.class, PartialMdExportToken.class) {
             @Override
             public void handlePollResult(TaskStatus pollResult) {

--- a/src/main/java/com/gooddata/md/maintenance/PartialMdArtifact.java
+++ b/src/main/java/com/gooddata/md/maintenance/PartialMdArtifact.java
@@ -1,10 +1,6 @@
 package com.gooddata.md.maintenance;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.*;
 import com.gooddata.gdc.UriResponse;
 
 /**
@@ -16,6 +12,7 @@ import com.gooddata.gdc.UriResponse;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class PartialMdArtifact {
 
+    @JsonProperty("status")
     private final UriResponse status;
     private final String token;
 
@@ -25,8 +22,9 @@ class PartialMdArtifact {
         this.token = token;
     }
 
-    public UriResponse getStatus() {
-        return status;
+    @JsonIgnore
+    public String getStatusUri() {
+        return status.getUri();
     }
 
     public String getToken() {

--- a/src/test/java/com/gooddata/md/DataLoadingColumnTest.java
+++ b/src/test/java/com/gooddata/md/DataLoadingColumnTest.java
@@ -22,8 +22,7 @@ public class DataLoadingColumnTest {
         final DataLoadingColumn column = new ObjectMapper().readValue(stream, DataLoadingColumn.class);
         assertThat(column, is(notNullValue()));
 
-        assertThat(column.getColumnUri(), is(notNullValue()));
-        assertThat(column.getColumnUri().getUri(), is("/gdc/md/PROJECT_ID/obj/COLUMN_ID"));
+        assertThat(column.getColumnUri(), is("/gdc/md/PROJECT_ID/obj/COLUMN_ID"));
 
         assertThat(column.getType(), is("INT"));
         assertThat(column.hasTypeInt(), is(true));

--- a/src/test/java/com/gooddata/md/maintenance/PartialMdArtifactTest.java
+++ b/src/test/java/com/gooddata/md/maintenance/PartialMdArtifactTest.java
@@ -17,7 +17,7 @@ public class PartialMdArtifactTest {
         final InputStream input = getClass().getResourceAsStream("/md/maintenance/partialMDArtifact.json");
         final PartialMdArtifact partialMdArtifact = new ObjectMapper().readValue(input, PartialMdArtifact.class);
 
-        assertThat(partialMdArtifact.getStatus().getUri(), is("/gdc/md/projectId/tasks/taskId/status"));
+        assertThat(partialMdArtifact.getStatusUri(), is("/gdc/md/projectId/tasks/taskId/status"));
         assertThat(partialMdArtifact.getToken(), is("TOKEN123"));
     }
 


### PR DESCRIPTION
Unfortunately the change in DataLoadingColumn is
not backward compatible. On the other hand this
Object has been added recently.