### PR TITLE
fix: ignore links field on metrics

### DIFF
--- a/src/main/java/com/gooddata/md/Metric.java
+++ b/src/main/java/com/gooddata/md/Metric.java
@@ -5,6 +5,7 @@ package com.gooddata.md;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -18,6 +19,7 @@ import java.util.Collection;
 @JsonTypeName("metric")
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties("links")
 public class Metric extends AbstractObj implements Queryable, Updatable {
 
     @JsonProperty("content")

--- a/src/test/java/com/gooddata/md/MetricTest.java
+++ b/src/test/java/com/gooddata/md/MetricTest.java
@@ -57,4 +57,11 @@ public class MetricTest {
         assertThat(metric, jsonNodeAbsent("metric.content.tree.content[0].content[0].content[0].content"));
         assertThat(metric, serializesToJson("/md/metric-out.json"));
     }
+
+    @Test
+    public void shouldIgnoreLinksProperty() throws Exception {
+        final Metric metric = new ObjectMapper()
+                .readValue(getClass().getResourceAsStream("/md/metric-links.json"), Metric.class);
+        assertThat(metric, serializesToJson("/md/metric-out.json"));
+    }
 }

--- a/src/test/resources/md/metric-links.json
+++ b/src/test/resources/md/metric-links.json
@@ -1,0 +1,61 @@
+{
+    "metric": {
+        "content": {
+            "format": "#,##0",
+            "tree": {
+                "content": [
+                    {
+                        "content": [
+                            {
+                                "value": "AVG",
+                                "content": [
+                                    {
+                                        "value": "/gdc/md/PROJECT_ID/obj/EXPR_ID",
+                                        "position": {
+                                            "column": 12,
+                                            "line": 2
+                                        },
+                                        "type": "fact object"
+                                    }
+                                ],
+                                "position": {
+                                    "column": 8,
+                                    "line": 2
+                                },
+                                "type": "function"
+                            }
+                        ],
+                        "position": {
+                            "column": 8,
+                            "line": 2
+                        },
+                        "type": "expression"
+                    }
+                ],
+                "position": {
+                    "column": 1,
+                    "line": 2
+                },
+                "type": "metric"
+            },
+            "expression": "SELECT AVG([/gdc/md/PROJECT_ID/obj/EXPR_ID])"
+        },
+        "links": {
+            "explain2": "/gdc/md/cpn1dbltx3at2wrmfl79inlxs76oxb7h/obj/47/explain2"
+        },
+        "meta": {
+            "author": "/gdc/account/profile/PROFILE_ID",
+            "uri": "/gdc/md/PROJECT_ID/obj/47",
+            "tags": "",
+            "created": "2015-10-10 12:56:13",
+            "identifier": "MY_ID",
+            "deprecated": "0",
+            "summary": "",
+            "isProduction": 1,
+            "title": "Avg shoe size",
+            "category": "metric",
+            "updated": "2015-10-10 12:56:13",
+            "contributor": "/gdc/account/profile/PROFILE_ID"
+        }
+    }
+}


### PR DESCRIPTION
This field is added in R119, and because of Metric object doesn't ignore unknown fileds, the deserialization fails.
Close: #339