### PR TITLE
rename getAccount() to getAccountById() and introduce getAccountByUri()

### DIFF
--- a/src/main/java/com/gooddata/account/AccountService.java
+++ b/src/main/java/com/gooddata/account/AccountService.java
@@ -35,7 +35,7 @@ public class AccountService extends AbstractService {
      * @throws com.gooddata.GoodDataException when current account can't be accessed.
      */
     public Account getCurrent() {
-        return getAccount(Account.CURRENT_ID);
+        return getAccountById(Account.CURRENT_ID);
     }
 
     /**
@@ -66,7 +66,7 @@ public class AccountService extends AbstractService {
 
         try {
             final UriResponse uriResponse = restTemplate.postForObject(Account.ACCOUNTS_URI, account, UriResponse.class, organizationName);
-            return getAccount(Account.getId(uriResponse.getUri()));
+            return getAccountByUri(uriResponse.getUri());
         } catch (GoodDataException | RestClientException e) {
             throw new GoodDataException("Unable to create account", e);
         }
@@ -101,7 +101,7 @@ public class AccountService extends AbstractService {
      * @throws AccountNotFoundException when account for given id can't be found
      * @throws GoodDataException
      */
-    public Account getAccount(String id) {
+    public Account getAccountById(String id) {
         try {
             return restTemplate.getForObject(Account.URI, Account.class, id);
         } catch (GoodDataRestException e) {
@@ -113,6 +113,17 @@ public class AccountService extends AbstractService {
         } catch (RestClientException e) {
             throw new GoodDataException("Unable to get account", e);
         }
+    }
+
+    /**
+     * Get account for given account id
+     * @param uri to search for
+     * @return account for uri
+     * @throws AccountNotFoundException when account for given uri can't be found
+     * @throws GoodDataException
+     */
+    public Account getAccountByUri(String uri) {
+        return getAccountById(Account.getId(uri));
     }
 
 }

--- a/src/test/java/com/gooddata/account/AccountServiceAT.java
+++ b/src/test/java/com/gooddata/account/AccountServiceAT.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -42,7 +41,7 @@ public class AccountServiceAT extends AbstractGoodDataAT {
 
     @Test(groups = "isolated_domain", dependsOnMethods = "createAccount")
     public void getAccount() {
-        final Account foundAccount = accountService.getAccount(this.account.getId());
+        final Account foundAccount = accountService.getAccountById(this.account.getId());
 
         assertThat(foundAccount, is(notNullValue()));
         assertThat(foundAccount.getId(), is(notNullValue()));

--- a/src/test/java/com/gooddata/account/AccountServiceIT.java
+++ b/src/test/java/com/gooddata/account/AccountServiceIT.java
@@ -171,7 +171,7 @@ public class AccountServiceIT extends AbstractGoodDataIT {
                 .withBody(readFromResource(ACCOUNT))
                 .withStatus(200);
 
-        final Account created = gd.getAccountService().getAccount(ACCOUNT_ID);
+        final Account created = gd.getAccountService().getAccountById(ACCOUNT_ID);
 
         assertThat(created, notNullValue());
         assertThat(created.getFirstName(), is("Blah"));
@@ -185,7 +185,7 @@ public class AccountServiceIT extends AbstractGoodDataIT {
                 .respond()
                 .withStatus(404);
 
-        gd.getAccountService().getAccount(ACCOUNT_ID);
+        gd.getAccountService().getAccountById(ACCOUNT_ID);
     }
 
 }


### PR DESCRIPTION
This change is for the sake of consistency with project, data warehouse,... and it is not breaking backward compatibility, because it is introduced in unreleased version