### PR TITLE
fix: AttributeInGrid has always alias set

### DIFF
--- a/src/main/java/com/gooddata/md/report/AttributeInGrid.java
+++ b/src/main/java/com/gooddata/md/report/AttributeInGrid.java
@@ -44,11 +44,13 @@ public class AttributeInGrid implements GridElement {
     }
 
     /**
-     * Creates new instance.
+     * Creates new instance from given uri with empty alias
      * @param uri uri of displayForm of attribute to be in grid
+     * @deprecated because empty alias does not make much sense
      */
+    @Deprecated
     public AttributeInGrid(String uri) {
-        this(uri, null);
+        this(uri, "");
     }
 
     /**


### PR DESCRIPTION
Also deprecate the constructor without alias, since empty String is not very useful value for alias.

fixes #359 