### PR TITLE
Add creating schedules triggered by schedule and names for schedules

### DIFF
--- a/src/main/java/com/gooddata/dataload/processes/Schedule.java
+++ b/src/main/java/com/gooddata/dataload/processes/Schedule.java
@@ -49,17 +49,33 @@ public class Schedule {
     private String cron;
     private String timezone;
     private Integer reschedule;
+    private String triggerScheduleId;
     private final DateTime nextExecutionTime;
     private final int consecutiveFailedExecutionCount;
     private final Map<String, String> params;
     private final Map<String,String> links;
 
     public Schedule(final DataloadProcess process, final String executable, final String cron) {
+        this(process, executable);
+        this.cron = notEmpty(cron, "cron");
+    }
+
+    /**
+     * Creates schedule, which is triggered by execution of different schedule
+     * @param process process to create schedule for
+     * @param executable executable to be scheduled for execution
+     * @param triggerSchedule schedule, which will trigger created schedule
+     */
+    public Schedule(final DataloadProcess process, final String executable, final Schedule triggerSchedule) {
+        this(process, executable);
+        this.triggerScheduleId = notEmpty(notNull(triggerSchedule, "triggerSchedule").getId(), "triggerSchedule ID");
+    }
+
+    private Schedule(final DataloadProcess process, final String executable) {
         notNull(process, "process");
 
         this.type = MSETL_TYPE;
         this.state = ScheduleState.ENABLED.name();
-        this.cron = notEmpty(cron, "cron");
         this.params = new HashMap<>();
         this.params.put(PROCESS_ID, process.getId());
         process.validateExecutable(executable);
@@ -78,6 +94,7 @@ public class Schedule {
                      @JsonProperty("consecutiveFailedExecutionCount") final int consecutiveFailedExecutionCount,
                      @JsonProperty("params") final Map<String, String> params,
                      @JsonProperty("reschedule") final Integer reschedule,
+                     @JsonProperty("triggerScheduleId") final String triggerScheduleId,
                      @JsonProperty("links") final Map<String, String> links) {
         this.type = type;
         this.state = state;
@@ -87,6 +104,7 @@ public class Schedule {
         this.consecutiveFailedExecutionCount = consecutiveFailedExecutionCount;
         this.params = params;
         this.reschedule = reschedule;
+        this.triggerScheduleId = triggerScheduleId;
         this.links = links;
     }
 
@@ -188,6 +206,14 @@ public class Schedule {
      */
     public void setReschedule(Duration reschedule) {
         this.reschedule = notNull(reschedule, "reschedule").toStandardMinutes().getMinutes();
+    }
+
+    public String getTriggerScheduleId() {
+        return triggerScheduleId;
+    }
+
+    public void setTriggerScheduleId(final String triggerScheduleId) {
+        this.triggerScheduleId = triggerScheduleId;
     }
 
     @JsonIgnore

--- a/src/main/java/com/gooddata/dataload/processes/Schedule.java
+++ b/src/main/java/com/gooddata/dataload/processes/Schedule.java
@@ -50,6 +50,7 @@ public class Schedule {
     private String timezone;
     private Integer reschedule;
     private String triggerScheduleId;
+    private String name;
     private final DateTime nextExecutionTime;
     private final int consecutiveFailedExecutionCount;
     private final Map<String, String> params;
@@ -95,6 +96,7 @@ public class Schedule {
                      @JsonProperty("params") final Map<String, String> params,
                      @JsonProperty("reschedule") final Integer reschedule,
                      @JsonProperty("triggerScheduleId") final String triggerScheduleId,
+                     @JsonProperty("name") final String name,
                      @JsonProperty("links") final Map<String, String> links) {
         this.type = type;
         this.state = state;
@@ -105,6 +107,7 @@ public class Schedule {
         this.params = params;
         this.reschedule = reschedule;
         this.triggerScheduleId = triggerScheduleId;
+        this.name = name;
         this.links = links;
     }
 
@@ -214,6 +217,14 @@ public class Schedule {
 
     public void setTriggerScheduleId(final String triggerScheduleId) {
         this.triggerScheduleId = triggerScheduleId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
     }
 
     @JsonIgnore

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
@@ -42,6 +42,7 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     private DataloadProcess process;
     private DataloadProcess processAppstore;
     private Schedule schedule;
+    private Schedule triggeredSchedule;
 
     @Test(groups = "process", dependsOnGroups = "project")
     public void createProcess() throws Exception {
@@ -67,11 +68,20 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     }
 
     @Test(groups = "process", dependsOnMethods = "createSchedule")
+    public void createTriggeredSchedule() {
+        triggeredSchedule = gd.getProcessService().createSchedule(project, new Schedule(process, "sdktest.grf", schedule));
+
+        assertThat(triggeredSchedule, notNullValue());
+        assertThat(triggeredSchedule.getExecutable(), is("sdktest.grf"));
+        assertThat(triggeredSchedule.getTriggerScheduleId(), is(schedule.getId()));
+    }
+
+    @Test(groups = "process", dependsOnMethods = {"createSchedule", "createTriggeredSchedule"})
     public void listSchedules() {
         final PageableList<Schedule> collection = gd.getProcessService().listSchedules(project);
 
         assertThat(collection, notNullValue());
-        assertThat(collection, hasSize(1));
+        assertThat(collection, hasSize(2));
         assertThat(collection.getNextPage(), nullValue());
     }
 
@@ -144,8 +154,9 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     @Test(dependsOnGroups = "process")
     public void removeSchedule() {
         gd.getProcessService().removeSchedule(schedule);
+        gd.getProcessService().removeSchedule(triggeredSchedule);
         final Collection<Schedule> schedules = gd.getProcessService().listSchedules(project);
-        assertThat(schedules, not(hasItems(hasSameScheduleIdAs(schedule))));
+        assertThat(schedules, not(hasItems(hasSameScheduleIdAs(schedule), hasSameScheduleIdAs(triggeredSchedule))));
     }
 
 }

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
@@ -61,6 +61,7 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     public void createSchedule() {
         schedule = gd.getProcessService().createSchedule(project, new Schedule(process, "sdktest.grf", "0 0 * * *"));
         schedule.setReschedule(Duration.standardMinutes(15));
+        schedule.setName("sdkTestSchedule");
 
         assertThat(schedule, notNullValue());
         assertThat(schedule.getExecutable(), is("sdktest.grf"));

--- a/src/test/java/com/gooddata/dataload/processes/ScheduleTest.java
+++ b/src/test/java/com/gooddata/dataload/processes/ScheduleTest.java
@@ -68,6 +68,7 @@ public class ScheduleTest {
         assertThat(schedule.getExecutable(), is(EXECUTABLE));
         assertThat(schedule.getNextExecutionTime(), is(DateTime.parse("2013-11-16T00:00:00.000Z")));
         assertThat(schedule.getUri(), is("/gdc/projects/PROJECT_ID/schedules/SCHEDULE_ID"));
+        assertThat(schedule.getName(), is("scheduleName"));
     }
 
     @Test
@@ -105,6 +106,7 @@ public class ScheduleTest {
     public void testSerializationWithAllFields() {
         final Schedule schedule = new Schedule(process, EXECUTABLE, "0 0 * * *");
         schedule.setReschedule(Duration.standardMinutes(26));
+        schedule.setName("scheduleName");
 
         assertThat(schedule, serializesToJson("/dataload/processes/schedule-input-all-fields.json"));
     }

--- a/src/test/resources/dataload/processes/schedule-input-all-fields.json
+++ b/src/test/resources/dataload/processes/schedule-input-all-fields.json
@@ -1,5 +1,6 @@
 {
   "schedule": {
+    "name" : "scheduleName",
     "type": "MSETL",
     "state": "ENABLED",
     "reschedule" : 26,

--- a/src/test/resources/dataload/processes/schedule-triggered-input.json
+++ b/src/test/resources/dataload/processes/schedule-triggered-input.json
@@ -1,0 +1,11 @@
+{
+  "schedule": {
+    "type": "MSETL",
+    "state": "ENABLED",
+    "params": {
+      "PROCESS_ID": "process_id",
+      "EXECUTABLE": "Twitter/graph/twitter.grf"
+    },
+    "triggerScheduleId": "schedule_id"
+  }
+}

--- a/src/test/resources/dataload/processes/schedule-triggered.json
+++ b/src/test/resources/dataload/processes/schedule-triggered.json
@@ -1,0 +1,18 @@
+{
+  "schedule": {
+    "type": "MSETL",
+    "state": "DISABLED",
+    "params": {
+      "PROCESS_ID": "process_id",
+      "EXECUTABLE": "Twitter/graph/twitter.grf"
+    },
+    "triggerScheduleId": "trigger_schedule_id",
+    "timezone": "UTC",
+    "nextExecutionTime": "2013-11-16T00:00:00.000Z",
+    "consecutiveFailedExecutionCount": 0,
+    "links": {
+      "self": "/gdc/projects/PROJECT_ID/schedules/SCHEDULE_ID",
+      "executions": "/gdc/projects/PROJECT_ID/schedules/SCHEDULE_ID/executions"
+    }
+  }
+}

--- a/src/test/resources/dataload/processes/schedule.json
+++ b/src/test/resources/dataload/processes/schedule.json
@@ -1,5 +1,6 @@
 {
   "schedule": {
+    "name" : "scheduleName",
     "type": "MSETL",
     "state": "ENABLED",
     "params": {


### PR DESCRIPTION
Issue #374 
 - When creating schedule, you can either specify cron expression or different schedule, which triggers execution of created schedule (you cannot specify both)

-  You can also optionally set schedule name (which differs from default name of schedule set to name of executable)


