### PR TITLE
introduce update methods without project argument

### DIFF
--- a/src/main/java/com/gooddata/dataload/processes/ProcessService.java
+++ b/src/main/java/com/gooddata/dataload/processes/ProcessService.java
@@ -127,13 +127,27 @@ public class ProcessService extends AbstractService {
      * @param process to create
      * @param processData process data to upload
      * @return updated process
+     * @deprecated use {@link #updateProcess(DataloadProcess, File)}
      */
+    @Deprecated
     public DataloadProcess updateProcess(Project project, DataloadProcess process, File processData) {
+        return updateProcess(process, processData);
+    }
+
+    /**
+     * Update process with given data by given project.
+     * Process must have null path to prevent clashes with deploying from appstore.
+     *
+     * @param process to create
+     * @param processData process data to upload
+     * @return updated process
+     */
+    public DataloadProcess updateProcess(DataloadProcess process, File processData) {
         notNull(process, "process");
+        notNull(process.getUri(), "process.uri");
         notNull(processData, "processData");
-        notNull(project, "project");
         isTrue(process.getPath() == null, "Process path has to be null, use processData argument. If you want to update process from appstore, use method updateProcessFromAppstore()");
-        return postProcess(process, processData, getProcessUri(project, process.getId()));
+        return postProcess(process, processData, URI.create(process.getUri()));
     }
 
     /**
@@ -144,12 +158,29 @@ public class ProcessService extends AbstractService {
      * @param project project to which the process belongs
      * @param process to update
      * @return updated process
+     * @deprecated use {@link #updateProcessFromAppstore(DataloadProcess)}
      */
+    @Deprecated
     public FutureResult<DataloadProcess> updateProcessFromAppstore(Project project, DataloadProcess process) {
         notNull(project, "project");
         notNull(process, "process");
         notEmpty(process.getPath(), "process path must not be empty");
         return postProcess(process, getProcessUri(project, process.getId()), HttpMethod.PUT);
+    }
+
+    /**
+     * Update process with data from appstore by given project.
+     * Process must have set path field to valid appstore path in order to deploy from appstore.
+     * This method is asynchronous, because when deploying from appstore, deployment worker can be triggered.
+     *
+     * @param process to update
+     * @return updated process
+     */
+    public FutureResult<DataloadProcess> updateProcessFromAppstore(DataloadProcess process) {
+        notNull(process, "process");
+        notNull(process.getUri(), "process.uri");
+        notEmpty(process.getPath(), "process path must not be empty");
+        return postProcess(process, URI.create(process.getUri()), HttpMethod.PUT);
     }
 
     /**
@@ -323,18 +354,31 @@ public class ProcessService extends AbstractService {
     }
 
     /**
-     * Update connector integration
+     * Update the given schedule
      *
      * @param project  project
      * @param schedule to update
      * @return updated Schedule
      * @throws ScheduleNotFoundException when the schedule doesn't exist
+     * @deprecated use {@link #updateSchedule(Schedule)}
      */
+    @Deprecated
     public Schedule updateSchedule(final Project project, Schedule schedule) {
-        notNull(schedule, "schedule");
-        notNull(project, "project");
+        return updateSchedule(schedule);
+    }
 
-        final String uri = getScheduleUri(project, schedule.getId()).toString();
+    /**
+     * Update the given schedule
+     *
+     * @param schedule to update
+     * @return updated Schedule
+     * @throws ScheduleNotFoundException when the schedule doesn't exist
+     */
+    public Schedule updateSchedule(Schedule schedule) {
+        notNull(schedule, "schedule");
+        notNull(schedule.getUri(), "schedule.uri");
+
+        final String uri = schedule.getUri();
         try {
             final ResponseEntity<Schedule> response = restTemplate
                     .exchange(uri, HttpMethod.PUT, new HttpEntity<>(schedule), Schedule.class);

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
@@ -91,10 +91,10 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
         schedule.setState(ScheduleState.DISABLED);
         schedule.setReschedule(Duration.standardMinutes(26));
 
-        schedule = gd.getProcessService().updateSchedule(project, schedule);
+        schedule = gd.getProcessService().updateSchedule(schedule);
 
         assertThat(schedule.isEnabled(), is(false));
-        assertThat(gd.getProcessService().updateSchedule(project, schedule).getRescheduleInMinutes(), is(26));
+        assertThat(gd.getProcessService().updateSchedule(schedule).getRescheduleInMinutes(), is(26));
     }
 
     @Test(groups = "process", dependsOnGroups = "project")
@@ -109,7 +109,7 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
     @Test(groups = "process", dependsOnMethods = "createProcessFromGit")
     public void updateProcessFromGit() {
         processAppstore.setPath("${PUBLIC_APPSTORE}:tag/prodigy-testing:/test/rubyBonjour");
-        processAppstore = gd.getProcessService().updateProcessFromAppstore(project, processAppstore).get();
+        processAppstore = gd.getProcessService().updateProcessFromAppstore(processAppstore).get();
 
         assertThat(processAppstore.getExecutables(), contains("bonjour.rb"));
     }

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceIT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceIT.java
@@ -251,7 +251,7 @@ public class ProcessServiceIT extends AbstractGoodDataIT {
                 .withStatus(200);
 
         schedule.setState(ScheduleState.DISABLED);
-        final Schedule updated = gd.getProcessService().updateSchedule(project, schedule);
+        final Schedule updated = gd.getProcessService().updateSchedule(schedule);
         assertThat(updated, notNullValue());
         assertThat(updated.isEnabled(), is(false));
     }
@@ -364,7 +364,7 @@ public class ProcessServiceIT extends AbstractGoodDataIT {
                 .withBody(readFromResource("/dataload/processes/appstoreProcess.json"));
 
         process.setPath("${PUBLIC_APPSTORE}:tag/prodigy-testing:/test/rubyHello");
-        DataloadProcess updatedProcess = gd.getProcessService().updateProcessFromAppstore(project, process).get();
+        DataloadProcess updatedProcess = gd.getProcessService().updateProcessFromAppstore(process).get();
         assertThat(updatedProcess, notNullValue());
         assertThat(updatedProcess.getType(), is(equalTo(ProcessType.RUBY.toString())));
         assertThat(updatedProcess.getExecutables(), contains("hello.rb") );

--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceTest.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceTest.java
@@ -77,6 +77,7 @@ public class ProcessServiceTest {
         MockitoAnnotations.initMocks(this);
         processService = new ProcessService(restTemplate, accountService, dataStoreService);
         when(process.getId()).thenReturn(PROCESS_ID);
+        when(process.getUri()).thenReturn(DataloadProcess.TEMPLATE.expand(PROJECT_ID, PROCESS_ID).toString());
         when(project.getId()).thenReturn(PROJECT_ID);
         when(accountService.getCurrent()).thenReturn(account);
         when(account.getId()).thenReturn(ACCOUNT_ID);
@@ -134,32 +135,22 @@ public class ProcessServiceTest {
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testUpdateProcessWithNullProject() throws Exception {
-        processService.updateProcess(null, process, File.createTempFile("test", null));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testUpdateProcessWithNullProcess() throws Exception {
-        processService.updateProcess(project, null, File.createTempFile("test", null));
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testUpdateProcessWithNullFile() throws Exception {
-        processService.updateProcess(project, process, (File) null);
+        processService.updateProcess(null, File.createTempFile("test", null));
     }
 
     @Test(expectedExceptions = GoodDataException.class)
     public void testUpdateProcessWithRestClientError() throws Exception {
         when(restTemplate.exchange(eq(create(PROCESS_URI)), any(HttpMethod.class), any(HttpEntity.class),
                 eq(DataloadProcess.class))).thenThrow(new RestClientException(""));
-        processService.updateProcess(project, process, File.createTempFile("test", null));
+        processService.updateProcess(process, File.createTempFile("test", null));
     }
 
     @Test(expectedExceptions = GoodDataException.class)
     public void testUpdateProcessWithNoApiResponse() throws Exception {
         when(restTemplate.exchange(eq(create(PROCESS_URI)), any(HttpMethod.class), any(HttpEntity.class),
                 eq(DataloadProcess.class))).thenReturn(null);
-        processService.updateProcess(project, process, File.createTempFile("test", null));
+        processService.updateProcess(process, File.createTempFile("test", null));
     }
 
     @Test
@@ -167,7 +158,7 @@ public class ProcessServiceTest {
         when(restTemplate.exchange(eq(create(PROCESS_URI)), any(HttpMethod.class), any(HttpEntity.class),
                 eq(DataloadProcess.class))).thenReturn(new ResponseEntity<>(process, HttpStatus.OK));
         final DataloadProcess result = processService
-                .updateProcess(project, process, File.createTempFile("test", null));
+                .updateProcess(process, File.createTempFile("test", null));
         assertThat(result, is(process));
     }
 


### PR DESCRIPTION
It makes no sense to require the project argument for update methods, as the object to update already contains the URI.
Similary we don't require project argument for remove methods.