### PR TITLE
Fixed order of tests in ProcessServiceAT

### DIFF
--- a/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
+++ b/src/test/java/com/gooddata/dataload/processes/ProcessServiceAT.java
@@ -133,7 +133,7 @@ public class ProcessServiceAT extends AbstractGoodDataAT {
         processService.executeProcess(new ProcessExecution(process, "invalid.grf")).get();
     }
 
-    @Test(dependsOnGroups = "process")
+    @Test(dependsOnGroups = "process", dependsOnMethods = "removeSchedule")
     public void removeProcess() throws Exception {
         gd.getProcessService().removeProcess(process);
         gd.getProcessService().removeProcess(processAppstore);


### PR DESCRIPTION
process was removed before schedule, this caused exception, when trying to remove schedule of removed process