### PR TITLE
fix invalid report's domain serialization

### DIFF
--- a/src/main/java/com/gooddata/md/report/Report.java
+++ b/src/main/java/com/gooddata/md/report/Report.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import java.util.Collection;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 /**
  * Report
@@ -37,14 +38,14 @@ public class Report extends AbstractObj implements Queryable, Updatable {
         this.content = content;
     }
 
-    /* Just for serialization test */
-    Report(String title, String domain, String... definitions) {
-        super(new Meta(title));
-        content = new Content(asList(definitions), asList(domain));
-    }
-
+    /**
+     * Creates new report with given title and definitions
+     * @param title report title
+     * @param definitions report definitions
+     */
     public Report(String title, ReportDefinition... definitions) {
-        this(title, null, uris(definitions));
+        // domains must be empty list to be included in serialized form properly
+        this(new Meta(title), new Content(asList(uris(definitions)), emptyList()));
     }
 
     @JsonIgnore
@@ -57,7 +58,6 @@ public class Report extends AbstractObj implements Queryable, Updatable {
         return content.getDomains();
     }
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private static class Content {
         private final Collection<String> definitions;
         private final Collection<String> domains;

--- a/src/test/java/com/gooddata/md/report/ReportTest.java
+++ b/src/test/java/com/gooddata/md/report/ReportTest.java
@@ -13,11 +13,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ReportTest {
 
-    public static final String DEFINITION = "/gdc/md/PROJECT_ID/obj/DEF_ID";
-    public static final String DOMAIN = "/gdc/md/PROJECT_ID/obj/DOM_ID";
+    private static final String DEFINITION_URI = "/gdc/md/PROJECT_ID/obj/DEF_ID";
+    private static final String DOMAIN_URI = "/gdc/md/PROJECT_ID/obj/DOM_ID";
 
     @Test
     public void testDeserialization() throws Exception {
@@ -25,16 +27,19 @@ public class ReportTest {
         assertThat(report, is(notNullValue()));
         assertThat(report.getDefinitions(), is(notNullValue()));
         assertThat(report.getDefinitions(), hasSize(1));
-        assertThat(report.getDefinitions().iterator().next(), is(DEFINITION));
+        assertThat(report.getDefinitions().iterator().next(), is(DEFINITION_URI));
 
         assertThat(report.getDomains(), is(notNullValue()));
         assertThat(report.getDomains(), hasSize(1));
-        assertThat(report.getDomains().iterator().next(), is(DOMAIN));
+        assertThat(report.getDomains().iterator().next(), is(DOMAIN_URI));
     }
 
     @Test
     public void testSerialization() throws Exception {
-        final Report report = new Report("Beers Consumed This Week", DOMAIN, DEFINITION);
+        final ReportDefinition definition = mock(ReportDefinition.class);
+        when(definition.getUri()).thenReturn(DEFINITION_URI);
+
+        final Report report = new Report("Beers Consumed This Week", definition);
         assertThat(report, serializesToJson("/md/report/report-input.json"));
     }
 

--- a/src/test/resources/md/report/report-input.json
+++ b/src/test/resources/md/report/report-input.json
@@ -1,9 +1,7 @@
 {
     "report" : {
         "content" : {
-            "domains" : [
-                "/gdc/md/PROJECT_ID/obj/DOM_ID"
-            ],
+            "domains" : [],
             "definitions" : [
                 "/gdc/md/PROJECT_ID/obj/DEF_ID"
             ]


### PR DESCRIPTION
Also removing protected report's constructor since I believe it makes no sense to test
serialization of something what can't be created by SDK user.

resolves #384 